### PR TITLE
Don't center map when player's not moving

### DIFF
--- a/Leatrix_Maps.lua
+++ b/Leatrix_Maps.lua
@@ -534,7 +534,7 @@
 			-- Function to update map
 			local function cUpdate(self, elapsed)
 				if cTime > 2 or cTime == -1 then
-					if WorldMapFrame.ScrollContainer:IsPanning() or IsShiftKeyDown() then return end
+					if WorldMapFrame.ScrollContainer:IsPanning() or IsShiftKeyDown() or GetUnitSpeed("player") == 0 then return end
 					local position = C_Map.GetPlayerMapPosition(WorldMapFrame.mapID, "player")
 					if position then
 						local x, y = position.x, position.y


### PR DESCRIPTION
Having to hold down shift to prevent the map from centering on the player makes it inconvenient/impossible to interact with POIs like Tom Tom markers, Handy Notes, Rare Scanner, etc. 

This update prevents the map from centering on the player when they are not moving.